### PR TITLE
Make sure webpack service runs last

### DIFF
--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -6,6 +6,8 @@ services:
       args:
         - "NODE_ENV=${NODE_ENV:-production}"
     command: "yarn run watch"
+    depends_on:
+      - "web"
     env_file:
       - ".env"
     restart: "${DOCKER_RESTART_POLICY:-unless-stopped}"


### PR DESCRIPTION
Not sure why but on my M1 Mac at least, web seems to be the last service to run, overwriting everything that's emitted from Webpack. This makes sure that Webpack is the last service to run, so that emitted files are not being overwritten.

Resolves #4.