### PR TITLE
Optionally rename non-web test directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - `COPY --chown=node:node ../ ../` has been fixed to be `COPY --chown=node:node . ..`
+- Ensure the `rename-project` script renames your project after adding custom non-web tests
 
 ## [0.5.0] - 2021-12-26
 

--- a/bin/rename-project
+++ b/bin/rename-project
@@ -53,6 +53,7 @@ find . -type f -exec \
   && mv lib/"${FIND_APP_NAME}"_web.ex lib/"${APP_NAME}"_web.ex \
   && mv lib/"${FIND_APP_NAME}" lib/"${APP_NAME}" \
   && mv lib/"${FIND_APP_NAME}"_web lib/"${APP_NAME}"_web \
+  && mv test/"${FIND_APP_NAME}" test/"${APP_NAME}" 2> /dev/null || true \
   && mv test/"${FIND_APP_NAME}"_web test/"${APP_NAME}"_web
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
The rename script was missing the folder for `test/myapp/*`, this adds it in similar to how the lib folders are done.