### PR TITLE
Update run ci:test task

### DIFF
--- a/run
+++ b/run
@@ -169,7 +169,7 @@ function ci:test {
   shellcheck run bin/*
   lint:dockerfile "${@}"
 
-  cp --no-clobber .env.example .env
+  cp .env.example .env 2>/dev/null || :
 
   docker compose build
   docker compose up -d


### PR DESCRIPTION
task error 
```
./run ci:test
cp: illegal option -- -
usage: cp [-R [-H | -L | -P]] [-fi | -n] [-aclpsvXx] source_file target_file
       cp [-R [-H | -L | -P]] [-fi | -n] [-aclpsvXx] source_file ... target_directory
```


The `--no-clobber` option is not available on all versions of cp. To avoid this error, you can replace the `cp --no-clobber` command with `cp -n` which should work on most systems.

use the `-n` option instead of `--no-clobber`. Note that `2>/dev/null || :`  has also been added after the cp command to ignore any error messages that might be produced.